### PR TITLE
Fix some typos in README.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!patches/**
+!linux-wasm.sh

--- a/README.md
+++ b/README.md
@@ -72,21 +72,21 @@ There are two containers:
 * **linux-wasm-contained**: Actually builds everything into the container. Meant as a dispoable way to build everything isolated.
 
 Create the containers:
-```
+```bash
 docker build -t linux-wasm-base:dev ./docker/linux-wasm-base
-docker build -t linux-wasm-contained:dev ./docker/linux-wasm-contained
+docker build -t linux-wasm-contained:dev -f ./docker/linux-wasm-contained/Dockerfile .
 ```
 Note that the latter command will copy linux-wasm.sh, in its current state, into the container.
 
 To launch a simple docker container with a mapping to host (recommended for development):
-```
+```bash
 docker run -it --name my-linux-wasm --mount type=bind,src="$(pwd)",target=/linux-wasm linux-wasm-base:dev bash
 (Inside the bash prompt, run for example:) /linux-wasm/linux-wasm.sh all
 ```
 
 To actually build everything inside the container (mostly useful for build servers):
-```
-docker run -it -name full-linux-wasm linux-wasm-contained:dev /linux-wasm/linux-wasm.sh all
+```bash
+docker run -it --name full-linux-wasm linux-wasm-contained:dev /linux-wasm/linux-wasm.sh all
 ```
 
 To change workspace folder, docker run -e LW_WORKSPACE=/path/to/workspace ...blah... can be used. This may be useful together with docker volumes.

--- a/docker/linux-wasm-base/Dockerfile
+++ b/docker/linux-wasm-base/Dockerfile
@@ -12,5 +12,5 @@ RUN apt update && \
     apt update && \
     test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
     apt install -y kitware-archive-keyring && \
-    apt install -y build-essential git cmake ninja-build && \
+    apt install -y build-essential git cmake ninja-build python3 flex bison bc rsync cpio && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/linux-wasm-base/Dockerfile
+++ b/docker/linux-wasm-base/Dockerfile
@@ -14,3 +14,8 @@ RUN apt update && \
     apt install -y kitware-archive-keyring && \
     apt install -y build-essential git cmake ninja-build python3 flex bison bc rsync cpio && \
     rm -rf /var/lib/apt/lists/*
+
+# Prevent git asking for user
+# Corresponds to:
+RUN git config --system user.email "you@example.com"
+RUN git config --system user.name "Your Name"


### PR DESCRIPTION
Building the docker container failed due to some typos.

Fixed and tested. Successfully build

```
docker build -t linux-wasm-base:dev ./docker/linux-wasm-base
docker build -t linux-wasm-contained:dev -f ./docker/linux-wasm-contained/Dockerfile .
docker run -it --name full-linux-wasm linux-wasm-contained:dev /linux-wasm/linux-wasm.sh all
```