### PR TITLE
runtime: Fix Cache-Control header typo

### DIFF
--- a/runtime/server.py
+++ b/runtime/server.py
@@ -18,7 +18,7 @@ class Server(SimpleHTTPRequestHandler):
   def end_headers(self):
     self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
     self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
-    self.send_header('Cache-Control:', 'no-store')
+    self.send_header('Cache-Control', 'no-store')
     SimpleHTTPRequestHandler.end_headers(self)
 
 if __name__ == '__main__':


### PR DESCRIPTION
I noticed that the response send `Cache-Control:: no-store` (double colons) in headers, so I traced it to server.py and found that header name argument has a trailing `:` that `send_header()` already adds itself.

- Before fix (The 304 response in the screenshot confirms the cache is being honored despite the intended no-store.)
<img width="742" height="693" alt="image" src="https://github.com/user-attachments/assets/694bdd18-73fd-4897-83f5-69f1fd1c18d8" />

- After fix
<img width="742" height="693" alt="image" src="https://github.com/user-attachments/assets/6f7196e1-31ab-43c6-b42d-4743526fbabc" />

P.S. I think this is also why browser may ignore the cache-control header mentioned at `runtime/index.html:8`.

> Append ?v=-1 to the URL to cache-bust smug browsers that ignore your Cache-Control headers.
